### PR TITLE
Configure Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+# Configuration for Codecov (https://codecov.io)
+
+ignore:
+  - Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ jobs:
       xcode_scheme: Identifier-Package
       xcode_destination: 'platform=macOS'
       install: swift package generate-xcodeproj --enable-code-coverage
+      before_install: echo "@available(*, unavailable) func doNothing() {}" > Sources/Identifier/_CoverageHack.swift # Add a second source file to appease Codecov processing
       after_success: bash <(curl -s https://codecov.io/bash)
     - <<: *xcode
       name: iOS / Xcode 10.2 / Swift 5.0


### PR DESCRIPTION
Due to an issue where Codecov fails to process coverage reports from single-file targets [1], this PR configure Travis CI to add a second, unused source file to fix coverage reporting.

[1]: The underlying issue is that the coverage report file for a target doesn't include source file paths for the coverage data unless there are at least two source files with coverage data. See https://community.codecov.io/t/there-was-an-error-processing-coverage-reports/79/2