### PR TITLE
Add the `--disable-automatic-resolution` flag to `swift test` CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ jobs:
   include:
     - stage: pretest
       name: Validate Linux test manifest
-      install: swift test --generate-linuxmain
+      install: swift test --generate-linuxmain --disable-automatic-resolution
       script: git diff --exit-code
 
     - &spm
       stage: test
       name: macOS / SPM 5.0 / Swift 5.0
-      script: swift test -Xswiftc -swift-version -Xswiftc 5
+      script: swift test --disable-automatic-resolution -Xswiftc -swift-version -Xswiftc 5
     - <<: *spm
       name: Linux / SPM 5.0 / Swift 5.0
       os: linux


### PR DESCRIPTION
This prevents SPM from updating the resolved package dependencies, which will cause the CI job to fail if `Package.resolved` is out of date.

https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_release_notes/swift_5_release_notes_for_xcode_10_2#3136858