### PR TITLE
Add a SwiftLint build phase

### DIFF
--- a/Identifier.xcodeproj/project.pbxproj
+++ b/Identifier.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 50;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		C9425DEB227555DC00EF93BD /* Lint Identifier */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = C9425DEE227555DD00EF93BD /* Build configuration list for PBXAggregateTarget "Lint Identifier" */;
+			buildPhases = (
+				C9425DEF227555EA00EF93BD /* Run SwiftLint */,
+			);
+			dependencies = (
+			);
+			name = "Lint Identifier";
+			productName = "Lint Identifier";
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		C97980FE224FE68800132BEC /* Identifier.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C97980F4224FE68800132BEC /* Identifier.framework */; };
 		C9798103224FE68800132BEC /* IdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9798102224FE68800132BEC /* IdentifierTests.swift */; };
@@ -151,6 +165,9 @@
 				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Matt Rubin";
 				TargetAttributes = {
+					C9425DEB227555DC00EF93BD = {
+						CreatedOnToolsVersion = 10.2.1;
+					};
 					C97980F3224FE68800132BEC = {
 						CreatedOnToolsVersion = 10.2;
 					};
@@ -173,9 +190,31 @@
 			targets = (
 				C97980F3224FE68800132BEC /* Identifier */,
 				C97980FC224FE68800132BEC /* IdentifierTests */,
+				C9425DEB227555DC00EF93BD /* Lint Identifier */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		C9425DEF227555EA00EF93BD /* Run SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint is not installed. (https://github.com/realm/SwiftLint)\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C97980F0224FE68800132BEC /* Sources */ = {
@@ -205,6 +244,18 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		C9425DEC227555DD00EF93BD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		C9425DED227555DD00EF93BD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
 		C9798106224FE68800132BEC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C979812C224FF07C00132BEC /* Debug.xcconfig */;
@@ -285,6 +336,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		C9425DEE227555DD00EF93BD /* Build configuration list for PBXAggregateTarget "Lint Identifier" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C9425DEC227555DD00EF93BD /* Debug */,
+				C9425DED227555DD00EF93BD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C97980EE224FE68800132BEC /* Build configuration list for PBXProject "Identifier" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Identifier.xcodeproj/xcshareddata/xcschemes/Identifier.xcscheme
+++ b/Identifier.xcodeproj/xcshareddata/xcschemes/Identifier.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Identifier.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C9425DEB227555DC00EF93BD"
+               BuildableName = "Lint Identifier"
+               BlueprintName = "Lint Identifier"
+               ReferencedContainer = "container:Identifier.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction


### PR DESCRIPTION
Add a SwiftLint build phase in a dedicated aggregate target.

This setup allows the project to be linted on every build during development, because the lint target is included in the Identifier scheme's build list, but the linter will not be run on build if the framework is being built as a dependency of another project with its own scheme.