### PR TITLE
Update SwiftLint configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -61,8 +61,8 @@ opt_in_rules:
   - toggle_bool
   - unavailable_function
   - untyped_error_in_catch
+  - unused_declaration
   - unused_import
-  - unused_private_declaration
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_between_cases
   - vertical_whitespace_closing_braces

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,52 +14,75 @@ opt_in_rules:
   - closure_spacing
   - collection_alignment
   - conditional_returns_on_newline
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
   - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
   - convenience_type
   - discouraged_object_literal
   - discouraged_optional_boolean
   - discouraged_optional_collection
+  - empty_collection_literal
   - empty_count
   - empty_string
   - empty_xctest_method
+  - enum_case_associated_values_count
+  - expiring_todo
   - explicit_enum_raw_value
   - explicit_init
   - extension_access_modifier
   - fallthrough
   - fatal_error_message
   - file_name
+  - file_name_no_space
   - first_where
+  - flatmap_over_map_reduce
   - function_default_parameter_at_end
+  - ibinspectable_in_extension
   - identical_operands
   - implicit_return
   - implicitly_unwrapped_optional
   - joined_default_parameter
   - last_where
+  - legacy_multiple
   - legacy_random
   - let_var_whitespace
   - literal_expression_end_indentation
   - lower_acl_than_parent
+  - missing_docs
   - modifier_order
   - multiline_arguments
   - multiline_function_chains
   - multiline_literal_brackets
   - multiline_parameters
+  - multiline_parameters_brackets
   - nimble_operator
   - nslocalizedstring_key
+  - nslocalizedstring_require_bundle
   - operator_usage_whitespace
+  - optional_enum_case_matching
   - overridden_super_call
   - override_in_extension
   - pattern_matching_keywords
+  - prefer_self_type_over_type_of_self
+  - prefer_zero_over_explicit_init
+  - private_action
+  - private_outlet
+  - prohibited_interface_builder
   - prohibited_super_call
+  - raw_value_for_camel_cased_codable_enum
+  - reduce_into
   - redundant_nil_coalescing
   - redundant_type_annotation
   - single_test_class
   - sorted_first_last
   - static_operator
   - strict_fileprivate
+  - strong_iboutlet
   - switch_case_on_newline
   - toggle_bool
   - unavailable_function
+  - unowned_variable_capture
   - untyped_error_in_catch
   - unused_declaration
   - unused_import

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -95,8 +95,5 @@ opt_in_rules:
   - xct_specific_matcher
   - yoda_condition
 
-line_length:
-  ignores_function_declarations: true
-
 trailing_comma:
   mandatory_comma: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -43,6 +43,7 @@ opt_in_rules:
   - identical_operands
   - implicit_return
   - implicitly_unwrapped_optional
+  - indentation_width
   - joined_default_parameter
   - last_where
   - legacy_multiple

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -37,6 +37,7 @@ opt_in_rules:
   - file_name_no_space
   - first_where
   - flatmap_over_map_reduce
+  - force_unwrapping
   - function_default_parameter_at_end
   - ibinspectable_in_extension
   - identical_operands

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Configuration for Travis (https://travis-ci.com)
 
 os: osx
-osx_image: xcode10.2
+osx_image: xcode11
 language: swift
 
 stages:
@@ -17,7 +17,7 @@ jobs:
 
     - &spm
       stage: test
-      name: SPM @ Xcode 10.2 / macOS
+      name: SPM @ Xcode 11 / macOS
       script: swift test --disable-automatic-resolution
     - <<: *spm
       name: SPM 5.0 / Linux
@@ -27,26 +27,26 @@ jobs:
       install: eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 
     - &cocoapods
-      name: CocoaPods & Xcode 10.2 / pod lib lint
+      name: CocoaPods & Xcode 11 / pod lib lint
       script: pod lib lint
 
     - &carthage
-      name: Carthage & Xcode 10.2 / carthage build --archive
+      name: Carthage & Xcode 11 / carthage build --archive
       script: carthage build --archive
 
     - &xcode
-      name: Xcode 10.2 / macOS
+      name: Xcode 11 / macOS
       xcode_project: Identifier.xcodeproj
       xcode_scheme: Identifier
       xcode_destination: 'platform=macOS'
     - <<: *xcode
-      name: Xcode 10.2 / iOS
+      name: Xcode 11 / iOS
       xcode_destination: 'OS=12.2,name=iPhone SE'
     - <<: *xcode
-      name: Xcode 10.2 / tvOS
+      name: Xcode 11 / tvOS
       xcode_destination: 'OS=12.2,name=Apple TV'
     - <<: *xcode
-      name: Xcode 10.2 / watchOS
+      name: Xcode 11 / watchOS
       xcode_destination: 'OS=5.2,name=Apple Watch Series 2 - 38mm'
       script: set -o pipefail && xcodebuild -project "$TRAVIS_XCODE_PROJECT" -scheme "$TRAVIS_XCODE_SCHEME" -destination "$TRAVIS_XCODE_DESTINATION" build | xcpretty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ jobs:
       name: SPM @ Xcode 11 / macOS
       script: swift test --disable-automatic-resolution
     - <<: *spm
-      name: SPM 5.0 / Linux
+      name: SPM 5.1 / Linux
       os: linux
       language: generic
-      env: SWIFT_VERSION=5.0 
+      env: SWIFT_VERSION=5.1
       install: eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 
     - &cocoapods

--- a/Sources/Identifier/Identifier.swift
+++ b/Sources/Identifier/Identifier.swift
@@ -8,7 +8,7 @@ public struct Identifier<T>: Equatable, Hashable {
     }
 
     public static func random() -> Identifier {
-        return self.init(uuid: UUID())
+        self.init(uuid: UUID())
     }
 }
 
@@ -25,14 +25,14 @@ extension Identifier: LosslessStringConvertible {
 
     /// A string representation of this identifier.
     public var description: String {
-        return uuid.uuidString
+        uuid.uuidString
     }
 }
 
 extension Identifier: CustomDebugStringConvertible {
     /// A detailed string representation of this identifier, for use in debugging.
     public var debugDescription: String {
-        return "Identifier<\(T.self)>(uuid: \(uuid))"
+        "Identifier<\(T.self)>(uuid: \(uuid))"
     }
 }
 

--- a/Tests/IdentifierTests/IdentifierTests.swift
+++ b/Tests/IdentifierTests/IdentifierTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 import Identifier
 
+// swiftlint:disable force_unwrapping
+
 let firstUUID = UUID(uuidString: "B9212942-B5B9-4547-A994-375921769411")!
 let secondUUID = UUID(uuidString: "1552BA9E-8378-489F-B6BC-E810973931E0")!
 

--- a/Tests/IdentifierTests/IdentifierTests.swift
+++ b/Tests/IdentifierTests/IdentifierTests.swift
@@ -99,8 +99,9 @@ final class IdentifierTests: XCTestCase {
         let json = "[\"3B46CDCE-A7D1-424A-AD2C-99FCD200F1A2\"]".data(using: .utf8)!
 
         let decoder = JSONDecoder()
-        XCTAssertEqual(try decoder.decode(JSONFragmentEncodingWrapper<Identifier<Void>>.self, from: json).value,
-                       Identifier(uuid: uuid))
+        XCTAssertEqual(
+            try decoder.decode(JSONFragmentEncodingWrapper<Identifier<Void>>.self, from: json).value,
+            Identifier(uuid: uuid))
 
         let emptyJSON = Data()
         XCTAssertThrowsError(


### PR DESCRIPTION
Enable several new opt-in rules, and:
  - Disallow force-unwrapping outside of tests
  - Wrap both arguments of a line-wrapped function call
  - Use implicit returns where possible