### PR TITLE
Add `RawRepresentable` conformance

### DIFF
--- a/Sources/Identifier/Identifier.swift
+++ b/Sources/Identifier/Identifier.swift
@@ -1,14 +1,14 @@
 import struct Foundation.UUID
 
-public struct Identifier<T>: Equatable, Hashable {
-    public let uuid: UUID
+public struct Identifier<T>: Equatable, Hashable, RawRepresentable {
+    public let rawValue: UUID
 
-    public init(uuid: UUID) {
-        self.uuid = uuid
+    public init(rawValue: UUID) {
+        self.rawValue = rawValue
     }
 
     public static func random() -> Identifier {
-        self.init(uuid: UUID())
+        self.init(rawValue: UUID())
     }
 }
 
@@ -20,19 +20,19 @@ extension Identifier: LosslessStringConvertible {
         guard let uuid = UUID(uuidString: description) else {
             return nil
         }
-        self.init(uuid: uuid)
+        self.init(rawValue: uuid)
     }
 
     /// A string representation of this identifier.
     public var description: String {
-        uuid.uuidString
+        rawValue.uuidString
     }
 }
 
 extension Identifier: CustomDebugStringConvertible {
     /// A detailed string representation of this identifier, for use in debugging.
     public var debugDescription: String {
-        "Identifier<\(T.self)>(uuid: \(uuid))"
+        "Identifier<\(T.self)>(rawValue: \(rawValue))"
     }
 }
 
@@ -40,10 +40,10 @@ extension Identifier: CustomDebugStringConvertible {
 
 extension Identifier: Codable {
     public init(from decoder: Decoder) throws {
-        uuid = try UUID(from: decoder)
+        rawValue = try UUID(from: decoder)
     }
 
     public func encode(to encoder: Encoder) throws {
-        try uuid.encode(to: encoder)
+        try rawValue.encode(to: encoder)
     }
 }

--- a/Tests/IdentifierTests/IdentifierTests.swift
+++ b/Tests/IdentifierTests/IdentifierTests.swift
@@ -7,10 +7,10 @@ let firstUUID = UUID(uuidString: "B9212942-B5B9-4547-A994-375921769411")!
 let secondUUID = UUID(uuidString: "1552BA9E-8378-489F-B6BC-E810973931E0")!
 
 final class IdentifierTests: XCTestCase {
-    func testInitWithUUID() {
+    func testInitWithRawValue() {
         let uuid = UUID()
-        let identifier = Identifier<Void>(uuid: uuid)
-        XCTAssertEqual(uuid, identifier.uuid)
+        let identifier = Identifier<Void>(rawValue: uuid)
+        XCTAssertEqual(uuid, identifier.rawValue)
     }
 
     func testRandomIdentifier() {
@@ -21,11 +21,11 @@ final class IdentifierTests: XCTestCase {
     }
 
     func testEquality() {
-        let first = Identifier<Void>(uuid: firstUUID)
+        let first = Identifier<Void>(rawValue: firstUUID)
         XCTAssertEqual(first, first)
 
-        let second = Identifier<Void>(uuid: secondUUID)
-        let secondAgain = Identifier<Void>(uuid: secondUUID)
+        let second = Identifier<Void>(rawValue: secondUUID)
+        let secondAgain = Identifier<Void>(rawValue: secondUUID)
         XCTAssertEqual(second, secondAgain)
 
         XCTAssertNotEqual(first, second)
@@ -43,13 +43,13 @@ final class IdentifierTests: XCTestCase {
     // MARK: - String Convertible
 
     func testInitWithDescription() {
-        let firstFromUUID = Identifier<Int>(uuid: firstUUID)
+        let firstFromUUID = Identifier<Int>(rawValue: firstUUID)
         let firstDescription = "B9212942-B5B9-4547-A994-375921769411"
         let firstFromDescription = Identifier<Int>(firstDescription)
         XCTAssertEqual(firstFromDescription, firstFromUUID)
 
         let secondRandom = Identifier<String>.random()
-        let secondDescription = secondRandom.uuid.uuidString
+        let secondDescription = secondRandom.rawValue.uuidString
         let secondFromDescription = Identifier<String>(secondDescription)
         XCTAssertEqual(secondFromDescription, secondRandom)
 
@@ -63,22 +63,22 @@ final class IdentifierTests: XCTestCase {
     }
 
     func testDescription() {
-        let first = Identifier<Int>(uuid: firstUUID)
+        let first = Identifier<Int>(rawValue: firstUUID)
         let firstExpectedDebugDescription = "B9212942-B5B9-4547-A994-375921769411"
         XCTAssertEqual(first.description, firstExpectedDebugDescription)
 
         let second = Identifier<String>.random()
-        let secondExpectedDebugDescription = second.uuid.uuidString
+        let secondExpectedDebugDescription = second.rawValue.uuidString
         XCTAssertEqual(second.description, secondExpectedDebugDescription)
     }
 
     func testDebugDescription() {
-        let first = Identifier<Int>(uuid: firstUUID)
-        let firstExpectedDebugDescription = "Identifier<Int>(uuid: B9212942-B5B9-4547-A994-375921769411)"
+        let first = Identifier<Int>(rawValue: firstUUID)
+        let firstExpectedDebugDescription = "Identifier<Int>(rawValue: B9212942-B5B9-4547-A994-375921769411)"
         XCTAssertEqual(first.debugDescription, firstExpectedDebugDescription)
 
         let second = Identifier<String>.random()
-        let secondExpectedDebugDescription = "Identifier<String>(uuid: " + second.uuid.uuidString + ")"
+        let secondExpectedDebugDescription = "Identifier<String>(rawValue: " + second.rawValue.uuidString + ")"
         XCTAssertEqual(second.debugDescription, secondExpectedDebugDescription)
     }
 
@@ -88,7 +88,7 @@ final class IdentifierTests: XCTestCase {
         let uuid = UUID(uuidString: "a80c0fdf-c1fe-4023-8ba3-dd1ad9b3cb94")!
         let expectedJSON = "[\"A80C0FDF-C1FE-4023-8BA3-DD1AD9B3CB94\"]".data(using: .utf8)!
 
-        let identifier = Identifier<Void>(uuid: uuid)
+        let identifier = Identifier<Void>(rawValue: uuid)
 
         let encoder = JSONEncoder()
         XCTAssertEqual(try encoder.encode(JSONFragmentEncodingWrapper(identifier)), expectedJSON)
@@ -101,7 +101,7 @@ final class IdentifierTests: XCTestCase {
         let decoder = JSONDecoder()
         XCTAssertEqual(
             try decoder.decode(JSONFragmentEncodingWrapper<Identifier<Void>>.self, from: json).value,
-            Identifier(uuid: uuid))
+            Identifier(rawValue: uuid))
 
         let emptyJSON = Data()
         XCTAssertThrowsError(

--- a/Tests/IdentifierTests/XCTestManifests.swift
+++ b/Tests/IdentifierTests/XCTestManifests.swift
@@ -12,7 +12,7 @@ extension IdentifierTests {
         ("testEncode", testEncode),
         ("testEquality", testEquality),
         ("testInitWithDescription", testInitWithDescription),
-        ("testInitWithUUID", testInitWithUUID),
+        ("testInitWithRawValue", testInitWithRawValue),
         ("testRandomIdentifier", testRandomIdentifier),
     ]
 }


### PR DESCRIPTION
This is an API-breaking change, as it renames the stored property and the initializer parameter to match the requirements of `RawRepresentable`.